### PR TITLE
Fix duplicating actions not working properly

### DIFF
--- a/src/Actions/DuplicateAssetAction.php
+++ b/src/Actions/DuplicateAssetAction.php
@@ -32,21 +32,23 @@ class DuplicateAssetAction extends Action
                 if ($item instanceof Asset) {
                     $duplicatePath = str_replace($item->filename(), "{$item->filename()}-02", $item->path());
 
-                    $assetMeta = $item->meta();
-                    $assetMeta['data'] = Arr::except($assetMeta['data'], config('duplicator.ignored_fields.assets'));
+                    $assetData = Arr::except(
+                        $item->data(),
+                        config('duplicator.ignored_fields.assets')
+                    );
 
                     if (config('duplicator.fingerprint') === true) {
-                        $assetMeta['is_duplicate'] = true;
+                        $assetData['is_duplicate'] = true;
                     }
+
+                    Storage::disk($item->container()->diskHandle())->copy($item->path(), $duplicatePath);
 
                     $asset = AssetAPI::make()
                         ->container($item->container()->handle())
-                        ->path($duplicatePath);
+                        ->path($duplicatePath)
+                        ->data($assetData);
 
                     $asset->save();
-                    $asset->writeMeta($assetMeta);
-
-                    Storage::disk($item->container()->diskHandle())->copy($item->path(), $duplicatePath);
                 }
             });
     }


### PR DESCRIPTION
This pull request fixes #49 (again!). 

It seems that in a recent Statamic update that something to do with asset metadata has changed causing duplicated assets to not work when the Stache watcher is disabled.

I believe this should now be fixed - I've moved the 'file copying' to above when we create the Asset instance in the Stache. I've also changed the way that we set the asset's metadata.