### PR TITLE
Attempt to support Statamic v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tests/__fixtures__/users/*.yaml
 tests/__fixtures__/content/collections/*.yaml
 tests/__fixtures__/content/collections/**/*.md
 composer.lock
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
         }
     },
     "require": {
-        "php": "^7.4 || ^8.0 || ^8.1",
-        "statamic/cms": "3.4.*"
+        "php": "^8.2",
+        "statamic/cms": "^4.0"
     },
     "require-dev": {
-        "nunomaduro/collision": "^4.2 || ^5.0 || ^6.1",
-        "orchestra/testbench": "^5.0 || ^6.0 || ^7.0"
+        "nunomaduro/collision": "^7.0",
+        "orchestra/testbench": "^8.0"
     },
     "scripts": {
         "lint": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,30 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         printerClass="NunoMaduro\Collision\Adapters\Phpunit\Printer">
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./app</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="APP_KEY" value="base64:xRIcDp1ReW8Y8rd9V9D7hOVV4TI7ThCF3FKxRg01Rm8="/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="QUEUE_DRIVER" value="sync"/>
-        <env name="MAIL_DRIVER" value="array"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage/>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="APP_KEY" value="base64:xRIcDp1ReW8Y8rd9V9D7hOVV4TI7ThCF3FKxRg01Rm8="/>
+    <env name="CACHE_DRIVER" value="array"/>
+    <env name="SESSION_DRIVER" value="array"/>
+    <env name="QUEUE_DRIVER" value="sync"/>
+    <env name="MAIL_DRIVER" value="array"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">./app</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Actions/DuplicateEntryAction.php
+++ b/src/Actions/DuplicateEntryAction.php
@@ -112,7 +112,7 @@ class DuplicateEntryAction extends Action
         $parentEntry = $entry
             ->structure()
             ->in($entry->locale())
-            ->page($entry->id())
+            ->find($entry->id())
             ->parent();
 
         if (! $parentEntry) {

--- a/src/Actions/DuplicateEntryAction.php
+++ b/src/Actions/DuplicateEntryAction.php
@@ -165,4 +165,9 @@ class DuplicateEntryAction extends Action
             'slug' => $slug,
         ];
     }
+
+    public function authorize($user, $item)
+    {
+        return $user->can('create', [AnEntry::class, $item->collection()]);
+    }
 }

--- a/src/Actions/DuplicateEntryAction.php
+++ b/src/Actions/DuplicateEntryAction.php
@@ -63,7 +63,6 @@ class DuplicateEntryAction extends Action
                         ->blueprint($item->blueprint()->handle())
                         ->locale(isset($values['site']) && $values['site'] !== 'all' ? $values['site'] : $item->locale())
                         ->published(config('duplicator.defaults.published', $item->published()))
-                        ->slug($itemTitleAndSlug['slug'])
                         ->data(
                             $item->data()
                                 ->except(config("duplicator.ignored_fields.entries.{$item->collectionHandle()}"))
@@ -72,6 +71,10 @@ class DuplicateEntryAction extends Action
                                 ])
                                 ->toArray()
                         );
+
+                    if ($item->collection()->requiresSlugs()) {
+                        $entry->slug($itemTitleAndSlug['slug']);
+                    }
 
                     if ($item->hasDate()) {
                         $entry->date($item->date());

--- a/src/Actions/DuplicateEntryAction.php
+++ b/src/Actions/DuplicateEntryAction.php
@@ -150,7 +150,7 @@ class DuplicateEntryAction extends Action
         $slug .= '-' . $attempt;
 
         // If the slug we've just built already exists, we'll try again, recursively.
-        if (Entry::findBySlug($slug, $entry->collection()->handle())) {
+        if (Entry::findByUri($slug, $entry->collection()->handle())) {
             $generate = $this->generateTitleAndSlug($entry, $attempt + 1);
 
             $title = $generate['title'];

--- a/src/Actions/DuplicateTermAction.php
+++ b/src/Actions/DuplicateTermAction.php
@@ -91,4 +91,9 @@ class DuplicateTermAction extends Action
             'slug' => $slug,
         ];
     }
+
+    public function authorize($user, $item)
+    {
+        return $user->can('create', [Term::class, $item->taxonomy()]);
+    }
 }

--- a/src/Actions/DuplicateTermAction.php
+++ b/src/Actions/DuplicateTermAction.php
@@ -79,7 +79,7 @@ class DuplicateTermAction extends Action
         $slug .= '-' . $attempt;
 
         // If the slug we've just built already exists, we'll try again, recursively.
-        if (TermAPI::findBySlug($slug, $term->taxonomy()->handle())) {
+        if (TermAPI::findByUri($slug, $term->taxonomy()->handle())) {
             $generate = $this->generateTitleAndSlug($term, $attempt + 1);
 
             $title = $generate['title'];

--- a/tests/Actions/DuplicateEntryActionTest.php
+++ b/tests/Actions/DuplicateEntryActionTest.php
@@ -74,6 +74,13 @@ class DuplicateEntryActionTest extends TestCase
         $collection = $this->makeCollection('guides', 'Guides');
         $entry = $this->makeEntry('guides', 'fresh-guide-smth', $this->user);
 
+        $collection->dated(true);
+        $collection->save();
+
+        $collection->entryBlueprint()->ensureFieldInTab('date', [
+            'type' => 'date',
+        ], 'sidebar');
+
         $entry = $entry->date(Carbon::parse('2021-08-08'));
         $entry->save();
 

--- a/tests/Actions/DuplicateEntryActionTest.php
+++ b/tests/Actions/DuplicateEntryActionTest.php
@@ -6,7 +6,6 @@ use Carbon\Carbon;
 use DoubleThreeDigital\Duplicator\Actions\DuplicateEntryAction;
 use DoubleThreeDigital\Duplicator\Tests\TestCase;
 use Illuminate\Support\Facades\Config;
-use Statamic\Facades\Entry;
 use Statamic\Structures\CollectionStructure;
 
 class DuplicateEntryActionTest extends TestCase
@@ -63,7 +62,7 @@ class DuplicateEntryActionTest extends TestCase
 
         $duplicate = $this->action->run(collect([$entry]), []);
 
-        $duplicateEntry = Entry::findBySlug('fresh-guide-1', 'guides');
+        $duplicateEntry = $this->findEntryBySlug('fresh-guide-1', 'guides');
 
         $this->assertIsObject($duplicateEntry);
         $this->assertSame($duplicateEntry->slug(), 'fresh-guide-1');
@@ -80,7 +79,7 @@ class DuplicateEntryActionTest extends TestCase
 
         $duplicate = $this->action->run(collect([$entry]), []);
 
-        $duplicateEntry = Entry::findBySlug('fresh-guide-smth-1', 'guides');
+        $duplicateEntry = $this->findEntryBySlug('fresh-guide-smth-1', 'guides');
 
         $this->assertIsObject($duplicateEntry);
         $this->assertSame($duplicateEntry->slug(), 'fresh-guide-smth-1');
@@ -117,7 +116,7 @@ class DuplicateEntryActionTest extends TestCase
 
         $duplicate = $this->action->run(collect([$entry]), []);
 
-        $duplicateEntry = Entry::findBySlug('sausage-roll-1', 'recipies');
+        $duplicateEntry = $this->findEntryBySlug('sausage-roll-1', 'recipies');
 
         // $this->assertIsObject($duplicateEntry);
         // $this->assertSame($duplicateEntry->slug(), 'sausage-roll-duplicate');
@@ -144,7 +143,7 @@ class DuplicateEntryActionTest extends TestCase
 
         $duplicate = $this->action->run(collect([$entry]), []);
 
-        $duplicateEntry = Entry::findBySlug('hello-world-1', 'blog');
+        $duplicateEntry = $this->findEntryBySlug('hello-world-1', 'blog');
 
         $this->assertIsObject($duplicateEntry);
         $this->assertSame($duplicateEntry->slug(), 'hello-world-1');
@@ -165,7 +164,7 @@ class DuplicateEntryActionTest extends TestCase
 
         $duplicate = $this->action->run(collect([$entry]), []);
 
-        $duplicateEntry = Entry::findBySlug('hello-universe-1', 'blog');
+        $duplicateEntry = $this->findEntryBySlug('hello-universe-1', 'blog');
 
         $this->assertIsObject($duplicateEntry);
         $this->assertSame($duplicateEntry->slug(), 'hello-universe-1');
@@ -191,7 +190,7 @@ class DuplicateEntryActionTest extends TestCase
 
         $duplicate = $this->action->run(collect([$entry]), []);
 
-        $duplicateEntry = Entry::findBySlug('fresh-guide-1', 'guides');
+        $duplicateEntry = $this->findEntryBySlug('fresh-guide-1', 'guides');
 
         $this->assertIsObject($duplicateEntry);
         $this->assertSame($duplicateEntry->slug(), 'fresh-guide-1');
@@ -208,7 +207,7 @@ class DuplicateEntryActionTest extends TestCase
 
         $duplicate = $this->action->run(collect([$entry]), []);
 
-        $duplicateEntry = Entry::findBySlug('new-guide-1', 'guides');
+        $duplicateEntry = $this->findEntryBySlug('new-guide-1', 'guides');
 
         $this->assertIsObject($duplicateEntry);
         $this->assertSame($duplicateEntry->slug(), 'new-guide-1');
@@ -226,7 +225,7 @@ class DuplicateEntryActionTest extends TestCase
 
         $duplicate = $this->action->run(collect([$entry]), []);
 
-        $duplicateEntry = Entry::findBySlug('news-guide-1', 'guides');
+        $duplicateEntry = $this->findEntryBySlug('news-guide-1', 'guides');
 
         $this->assertIsObject($duplicateEntry);
         $this->assertSame($duplicateEntry->slug(), 'news-guide-1');

--- a/tests/Actions/DuplicateTermActionTest.php
+++ b/tests/Actions/DuplicateTermActionTest.php
@@ -61,7 +61,7 @@ class DuplicateTermActionTest extends TestCase
 
         $duplicate = $this->action->run(collect([$term]), []);
 
-        $duplicateTerm = Term::findBySlug('haggis-1', 'categories');
+        $duplicateTerm = $this->findTermBySlug('haggis-1', 'categories');
 
         $this->assertIsObject($duplicateTerm);
         $this->assertSame($duplicateTerm->slug(), 'haggis-1');
@@ -79,7 +79,7 @@ class DuplicateTermActionTest extends TestCase
 
         $duplicate = $this->action->run(collect([$term]), []);
 
-        $duplicateTerm = Term::findBySlug('haggis-1', 'categories');
+        $duplicateTerm = $this->findTermBySlug('haggis-1', 'categories');
 
         $this->assertIsObject($duplicateTerm);
         $this->assertSame($duplicateTerm->slug(), 'haggis-1');
@@ -98,7 +98,7 @@ class DuplicateTermActionTest extends TestCase
 
         $duplicate = $this->action->run(collect([$term]), []);
 
-        $duplicateTerm = Term::findBySlug('haggis-1', 'categories');
+        $duplicateTerm = $this->findTermBySlug('haggis-1', 'categories');
 
         $this->assertIsObject($duplicateTerm);
         $this->assertSame($duplicateTerm->slug(), 'haggis-1');
@@ -124,7 +124,7 @@ class DuplicateTermActionTest extends TestCase
 
         $duplicate = $this->action->run(collect([$term]), []);
 
-        $duplicateTerm = Term::findBySlug('haggis-1', 'categories');
+        $duplicateTerm = $this->findTermBySlug('haggis-1', 'categories');
 
         $this->assertIsObject($duplicateTerm);
         $this->assertSame($duplicateTerm->slug(), 'haggis-1');
@@ -141,7 +141,7 @@ class DuplicateTermActionTest extends TestCase
 
         $duplicate = $this->action->run(collect([$term]), []);
 
-        $duplicateTerm = Term::findBySlug('spaghetti-1', 'categories');
+        $duplicateTerm = $this->findTermBySlug('spaghetti-1', 'categories');
 
         $this->assertIsObject($duplicateTerm);
         $this->assertSame($duplicateTerm->slug(), 'spaghetti-1');
@@ -159,7 +159,7 @@ class DuplicateTermActionTest extends TestCase
 
         $duplicate = $this->action->run(collect([$term]), []);
 
-        $duplicateTerm = Term::findBySlug('cheese-1', 'categories');
+        $duplicateTerm = $this->findTermBySlug('cheese-1', 'categories');
 
         $this->assertIsObject($duplicateTerm);
         $this->assertSame($duplicateTerm->slug(), 'cheese-1');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -126,15 +126,13 @@ abstract class TestCase extends OrchestraTestCase
 
     protected function makeTerm(string $taxonomyHandle, string $slug, AuthUser $user)
     {
-        Term::make($slug)
+        return tap(Term::make($slug)
             ->taxonomy($taxonomyHandle)
             ->data([
                 'title' => 'Blah blah blah',
                 'text' => $this->faker->text,
-            ])
+            ]))
             ->save();
-
-        return Term::findByUri($slug, $taxonomyHandle);
     }
 
     protected function findEntryBySlug(string $slug, string $collectionHandle)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -112,7 +112,7 @@ abstract class TestCase extends OrchestraTestCase
             ->set('updated_at', now()->timestamp)
             ->save();
 
-        return Entry::findBySlug($slug, $collectionHandle);
+        return $this->findEntryBySlug($slug, $collectionHandle);
     }
 
     protected function makeTaxonomies(string $handle, string $name)
@@ -134,6 +134,20 @@ abstract class TestCase extends OrchestraTestCase
             ])
             ->save();
 
-        return Term::findBySlug($slug, $taxonomyHandle);
+        return Term::findByUri($slug, $taxonomyHandle);
+    }
+
+    protected function findEntryBySlug(string $slug, string $collectionHandle)
+    {
+        return Entry::whereCollection($collectionHandle)
+            ->where('slug', $slug)
+            ->first();
+    }
+
+    protected function findTermBySlug(string $slug, string $taxonomyHandle)
+    {
+        return Term::whereTaxonomy($taxonomyHandle)
+            ->where('slug', $slug)
+            ->first();
     }
 }


### PR DESCRIPTION
Here's a half-attempt to support Statamic v4.

I've got the tests somewhat passing, admittedly jumping a few versions of testbench. Statamic's APIs seem to have changed too, so I did my best to get things working. I'm not familiar enough with it to get much further.

When I try to perform the action in Statamic, the following error occurs:

```
Call to undefined method Statamic\\Structures\\CollectionTree::page() at duplicator/src/Actions/DuplicateEntryAction.php:115)
```

I see that in the `Tree` class there is a `pages()` function, but indeed no `page()`. I think it's close? Not sure.