### PR TITLE
Add back PHP 8.1 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2]
+        php: [8.2, 8.1]
         laravel: [10.*]
         statamic: [^4.0]
         testbench: [8.*]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.framework }}" "statamic/cms:${{ matrix.statamic }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "statamic/cms:${{ matrix.statamic }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer install --no-interaction
 
       - name: Run PHPUnit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,19 +13,9 @@ jobs:
     strategy:
       matrix:
         php: [8.1, 8.2]
-        laravel: [9.*, 8.*]
-        statamic: [^3.4]
+        laravel: [10.*]
+        statamic: [^4.0]
         os: [ubuntu-latest]
-        include:
-          - laravel: 9.*
-            framework: ^9.1.0
-            testbench: 7.*
-          - laravel: 8.*
-            framework: ^8.24.0
-            testbench: 6.*
-        exclude:
-          - laravel: 9.*
-            php: 7.4
 
     name: ${{ matrix.php }} - ${{ matrix.statamic }} - ${{ matrix.laravel }}
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,9 +12,10 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1, 8.2]
+        php: [8.2]
         laravel: [10.*]
         statamic: [^4.0]
+        testbench: [8.*]
         os: [ubuntu-latest]
 
     name: ${{ matrix.php }} - ${{ matrix.statamic }} - ${{ matrix.laravel }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1, 8.0, 7.4]
+        php: [8.1, 8.2]
         laravel: [9.*, 8.*]
         statamic: [^3.4]
         os: [ubuntu-latest]

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.1 || ^8.2",
         "statamic/cms": "^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
This pull request adds back support for PHP 8.1 to the addon which was removed accidentally in #59.

However, folks should consider upgrading to PHP 8.2 when they can. 